### PR TITLE
タイマー機能を追加する

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -1,5 +1,5 @@
 -- Battle Matchmaker
--- Version 1.3.3
+-- Version 1.4.0
 
 g_players={}
 g_ui_id=0
@@ -94,7 +94,7 @@ g_commands={
 		name='die',
 		auth=true,
 		action=function(peer_id, is_admin, is_auth, target_peer_id)
-			if g_in_game then
+			if not g_in_game then
 				announce('Cannot die before game start.', peer_id)
 				return
 			end
@@ -394,7 +394,7 @@ function onTick()
 			setPopup('countdown', true, string.format('Start in\n%.0f', sec))
 		else
 			startGame()
-			notify('Game Start', "'Let's go!'", 9, -1)
+			notify('Game Start', "Let's go!", 9, -1)
 		end
 	end
 	if g_in_game then
@@ -632,7 +632,7 @@ function kill(peer_id)
 end
 
 function ready(peer_id)
-	if g_in_game or g_in_countdown then return end
+	if g_in_game then return end
 	local player=g_players[peer_id]
 	if not player or player.ready then return end
 	if not player.alive then
@@ -645,7 +645,7 @@ function ready(peer_id)
 end
 
 function wait(peer_id)
-	if g_in_game or not g_in_countdown then return end
+	if g_in_game then return end
 	local player=g_players[peer_id]
 	if not player or not player.ready then return end
 	player.ready=false
@@ -899,6 +899,7 @@ end
 function startGame()
 	g_in_game=true
 	g_in_countdown=false
+	g_status_dirty=true
 	g_timer=g_savedata.game_time_min*60*60//1|0
 	g_remind_interval=g_savedata.remind_time_min*60*60//1|0
 
@@ -908,6 +909,7 @@ end
 function finishGame()
 	g_in_game=false
 	g_in_countdown=false
+	g_status_dirty=true
 	setPopup('countdown', false)
 
 	setSettingsToStandby()

--- a/script.lua
+++ b/script.lua
@@ -620,7 +620,11 @@ end
 function ready(peer_id)
 	if g_in_game or g_in_countdown then return end
 	local player=g_players[peer_id]
-	if not player then return end
+	if not player or player.ready then return end
+	if not player.alive then
+		announce('Cannot ready for dead player.', peer_id)
+		return
+	end
 	player.ready=true
 	resume()
 	g_status_dirty=true
@@ -629,7 +633,7 @@ end
 function wait(peer_id)
 	if g_in_game or not g_in_countdown then return end
 	local player=g_players[peer_id]
-	if not player then return end
+	if not player or not player.ready then return end
 	player.ready=false
 	pause()
 	g_status_dirty=true

--- a/script.lua
+++ b/script.lua
@@ -869,7 +869,11 @@ function checkFinish()
 		team_aliver_counts[player.team]=count and (count+add) or add
 		any=true
 	end
-	if not any then return end
+	if not any then
+		finishGame()
+		notify('Game End', 'No player. Game is interrupted.', 6, -1)
+		return
+	end
 	local alive_team_count=0
 	local alive_team_name=''
 	for team_name,team_aliver_count in pairs(team_aliver_counts) do
@@ -990,7 +994,7 @@ end
 
 function notify(title, text, type, peer_id)
 	server.notify(-1, title, text, type)
-	announce(title..' '..text, peer_id)
+	announce(title..'\n'..text, peer_id)
 end
 
 function getTableCount(table)


### PR DESCRIPTION
ユニップさんの拡張アドオンをベースにしたタイマー機能を実装します

# 入るもの
- ready/waitによる準備状況の管理
- pause/resumeによるカウントダウンの操作
- set_**_timeによるタイマー類の設定
- ゲーム開始・終了処理

# 入らないもの
- 偵察機能
- 準備用ビークル呼び出し
- ~サーバー設定自動変更~ 入れました

# そのほか
- set系コマンドを `set_**` の形に統一しました
- join/orderコマンドはゲーム中は実行できないようになりました
- 生存者のいるチーム数が1以下になったらゲームを終了するようにしました
- Popupの管理方法を大幅に変更しました
  - サーバーに新しく入ったプレイヤーにはPopupが見えない事があるので、入るたびにui_idを更新するようにしている
  - 今回複数のPopupが表示されることになったので、配列で管理し変更があったときにonTickで更新するよう設計修正した