### PR TITLE
WebMap アドオン連携機能の追加

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -15,6 +15,9 @@ g_timer=0
 g_remind_interval=3600
 g_ui_reset_requested=false
 g_flag_radius=300
+--WebMapAddon
+g_has_webmap=false
+g_webMapBindings={}
 
 g_ammo_supply_buttons={
 	MG_K={42,50,'mg'},
@@ -614,6 +617,19 @@ function onCreate(is_world_create)
 	registerPopup('game_time', -0.9, -0.9)
 
 	setSettingsToStandby()
+
+	--WebMapAddonDetectCheck
+	count = server.getAddonCount()
+	for addon_index=0,count-1 do
+		local ADDON_DATA =server.getAddonData(addon_index)
+		local addon_name = string.lower(ADDON_DATA.name)
+		if addon_name == 'webmap' then
+			g_has_webmap=true
+			announce('Webmap addon detected!',0)
+			break
+		end
+	end
+
 end
 
 function onDestroy()
@@ -792,6 +808,10 @@ function onPlayerSit_(peer_id, vehicle_id, seat_name)
 	local vehicle=registerVehicle(vehicle_id)
 	if vehicle and vehicle.alive then
 		player.vehicle_id=vehicle_id
+		--WebMapAddon
+		if g_has_webmap then
+			bindVehicleTeamToWebMap(vehicle_id, player.team)
+		end
 	end
 	g_player_status_dirty=true
 end
@@ -881,6 +901,21 @@ function join(peer_id, team, force)
 		local vehicle=registerVehicle(vehicle_id)
 		if vehicle and vehicle.alive then
 			player.vehicle_id=vehicle_id
+			--webmapAddon
+			if g_has_webmap then
+				bindVehicleTeamToWebMap(vehicle_id, team)
+			end
+		end
+	else
+		--webmapAddon
+		--not sit
+		--Currently, it does not work because player.vehicle_id = -1 is set.
+		local vehicle=registerVehicle(player.vehicle_id)
+		if vehicle and vehicle.alive then
+			player.vehicle_id=vehicle_id
+			if g_has_webmap then
+				bindVehicleTeamToWebMap(vehicle_id, team)
+			end
 		end
 	end
 
@@ -931,6 +966,13 @@ function shuffle(team_count, exec_peer_id)
 		local team=g_default_teams[1+(i-1)%team_count]
 		g_players[peer_id].team=team
 		announce('You joined to '..team..'.', peer_id)
+		--webmapAddon
+		if g_has_webmap then
+			local vehicle=findVehicle(g_players[peer_id].vehicle_id)
+			if vehicle and vehicle.alive then
+				bindVehicleTeamToWebMap(g_players[peer_id].vehicle_id, team)
+			end
+		end
 		table.remove(peer_ids, pick)
 	end
 
@@ -1090,6 +1132,11 @@ function unregisterVehicle(vehicle_id)
 	if not vehicle then return end
 	table.remove(g_vehicles,index)
 
+	--WebMapAddon
+	if g_has_webmap then
+		g_webMapBindings[vehicle_id]=nil
+	end
+
 	for peer_id,player in pairs(g_players) do
 		if player.vehicle_id==vehicle_id then
 			player.vehicle_id=-1
@@ -1189,6 +1236,34 @@ function updateVehicle(vehicle)
 	g_player_status_dirty=true
 end
 
+--WebMapAddon(Called from the Join/Shuffle/Sit event.)
+function bindVehicleTeamToWebMap(vehicle_id, team)
+
+	if g_has_webmap==false then
+		return
+	end
+
+	if not vehicle_id or vehicle_id<0 then
+		return
+	end
+
+	local TEAM_COLOR_MAP = {
+		red = "RED",
+		blue = "BLUE",
+		pink = "PINK",
+		ylw = "YELLOW",
+		standby = "YELLOW"
+	}
+	team = string.lower(team)
+	local color = TEAM_COLOR_MAP[team]
+	if not color then return end
+
+	if g_webMapBindings[vehicle_id]==color then return end
+	g_webMapBindings[vehicle_id]=color
+	--?wm ct(WebMap_ChangeTeam)command
+	local cmd = '?wm ct ' .. vehicle_id .. ' ' .. color
+	server.command(cmd)
+end
 -- System Functions --
 
 function updateTeamStatus()

--- a/script.lua
+++ b/script.lua
@@ -901,13 +901,13 @@ function join(peer_id, team, force)
 		local vehicle=registerVehicle(vehicle_id)
 		if vehicle and vehicle.alive then
 			player.vehicle_id=vehicle_id
-			--webmapAddon
+			--WebMapAddon
 			if g_has_webmap then
 				bindVehicleTeamToWebMap(vehicle_id, team)
 			end
 		end
 	else
-		--webmapAddon
+		--WebMapAddon
 		--not sit
 		--Currently, it does not work because player.vehicle_id = -1 is set.
 		local vehicle=registerVehicle(player.vehicle_id)
@@ -966,7 +966,7 @@ function shuffle(team_count, exec_peer_id)
 		local team=g_default_teams[1+(i-1)%team_count]
 		g_players[peer_id].team=team
 		announce('You joined to '..team..'.', peer_id)
-		--webmapAddon
+		--WebMapAddon
 		if g_has_webmap then
 			local vehicle=findVehicle(g_players[peer_id].vehicle_id)
 			if vehicle and vehicle.alive then


### PR DESCRIPTION
概要
BattleMatchmaker から WebMap アドオンを自動検出し、
プレイヤーのチーム情報をリアルタイムで WebMap に反映する連携機能を追加します。.

変更内容
新機能
WebMap アドオン自動検出
onCreate 時にアドオン一覧をスキャンし、webmap アドオンが存在する場合に連携を有効化します。
車両へのチームカラーバインド
プレイヤーが着席・join・shuffleした際に ?wm ct <vehicle_id> <color> コマンドを通じて WebMap 側の車両カラーを自動更新します。
チームカラーマッピング
red / blue / pink / ylw / standby を WebMap のカラー名に変換します。
実装詳細
関数 / 箇所	変更内容
onCreate	アドオンスキャンによる g_has_webmap フラグの設定
onPlayerSit_	着席時に bindVehicleTeamToWebMap を呼び出し
join	join 時に bindVehicleTeamToWebMap を呼び出し
shuffle	シャッフル後に各プレイヤーの車両カラーを更新
unregisterVehicle	車両解除時に g_webMapBindings のエントリを削除
bindVehicleTeamToWebMap	新規追加。重複コマンド送信を防ぐキャッシュ付き